### PR TITLE
fix: Tag is out of date

### DIFF
--- a/lib/src/repositories/nfc_badge_repository.dart
+++ b/lib/src/repositories/nfc_badge_repository.dart
@@ -39,6 +39,7 @@ class NfcBadgeRepository {
     bool shouldCrop = true,
   }) {
     final controller = StreamController<double>();
+    final ditheredImage = image.getDitheredImage(kernel);
 
     Future(() async {
       final isNfcAvailable = await NfcManager.instance.isAvailable();
@@ -62,14 +63,14 @@ class NfcBadgeRepository {
                 if (Platform.isAndroid) {
                   await const AndroidNfcImplementation().writeOverNfc(
                     tag,
-                    image.getDitheredImage(kernel),
+                    ditheredImage,
                     controller,
                     shouldCrop: shouldCrop,
                   );
                 } else if (Platform.isIOS) {
                   await const IosNfcImplementation().writeOverNfc(
                     tag,
-                    image.getDitheredImage(kernel),
+                    ditheredImage,
                     controller,
                     shouldCrop: shouldCrop,
                   );


### PR DESCRIPTION
**Problem**:
Uploading non-default image to badge via my Android device (Samsung Galaxy A34 with Android 15) kept throwing `Tag is out of date` error. It turned out that it is thrown as soon as device tries to write bytes for the first time - at the beginning of `writeOverNfc` method:
```
// 1. Get badge specification from the device
final badge = await nfc
    .writeBytes(
      Uint8List.fromList([-48, -47, 3, 0, 1]),
    )
    .then(BadgeSpecification.fromSpecification);
```

**Solution**:
Before discovered tag is passed to mentioned method, library generates dithered image by calling `image.getDitheredImage(kernel)`. Potentially that is when the tag gets outdated - moving this call before NfcManager starts the session fixes the issue.

**Full error**:
```
E/flutter (12303): [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: PlatformException(SecurityException, java.lang.SecurityException: Permission Denial: Tag ( ID: 1D 89 B8 19 58 00 00 ) is out of date, Cause: null, Stacktrace: java.lang.SecurityException: Permission Denial: Tag ( ID: 1D 89 B8 19 58 00 00 ) is out of date
E/flutter (12303): 	at android.nfc.Tag.getTagService(Tag.java:381)
E/flutter (12303): 	at android.nfc.tech.BasicTagTechnology.connect(BasicTagTechnology.java:73)
E/flutter (12303): 	at android.nfc.tech.IsoDep.connect(IsoDep.java:40)
E/flutter (12303): 	at dev.flutter.plugins.nfcmanager.NfcManagerPlugin.isoDepTransceive(NfcManagerPlugin.kt:805)
E/flutter (12303): 	at dev.flutter.plugins.nfcmanager.HostApiPigeon$Companion.setUp$lambda$48$lambda$47(Pigeon.kt:1304)
E/flutter (12303): 	at dev.flutter.plugins.nfcmanager.HostApiPigeon$Companion.$r8$lambda$DMCXjnBDCoHyj2wa9ckqFwu3Jqk(Unknown Source:0)
E/flutter (12303): 	at dev.flutter.plugins.nfcmanager.HostApiPigeon$Companion$$ExternalSyntheticLambda6.onMessage(D8$$SyntheticClass:0)
E/flutter (12303): 	at io.flutter.plugin.common.BasicMessageChannel$IncomingMessageHandler.onMessage(BasicMessageChannel.java:261)
E/flutter (12303): 	at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:292)
E/flutter (12303): 	at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:319)
E/flutter (12303): 	at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
E/flutter (12303): 	at android.os.Handler.handleCallback(Handler.java:959)
E/flutter (12303): 	at android.os.Handler.dispatchMessage(Handler.java:100)
E/flutter (12303): 	at android.os.Looper.loopOnce(Looper.java:257)
E/flutter (12303): 	at android.os.Looper.loop(Looper.java:342)
E/flutter (12303): 	at android.app.ActivityThread.main(ActivityThread.java:9638)
E/flutter (12303): 	at java.lang.reflect.Method.invoke(Native Method)
E/flutter (12303): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:619)
E/flutter (12303): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
E/flutter (12303): , null)
E/flutter (12303): #0      HostApiPigeon.isoDepTransceive (package:nfc_manager/src/nfc_manager_android/pigeon.g.dart:1651:7)
E/flutter (12303): <asynchronous suspension>
E/flutter (12303): #1      BadgeSpecification.fromSpecification (package:friends_badge/src/utils/badge_specification.dart:25:3)
E/flutter (12303): <asynchronous suspension>
E/flutter (12303): #2      CommonNfcImplementation.writeOverNfc (package:friends_badge/src/repositories/nfc_implementations/common_nfc_implementation.dart:27:19)
E/flutter (12303): <asynchronous suspension>
E/flutter (12303): #3      NfcBadgeRepository.writeOverNfc.<anonymous closure>.<anonymous closure> (package:friends_badge/src/repositories/nfc_badge_repository.dart:63:19)
E/flutter (12303): <asynchronous suspension>
```